### PR TITLE
Update to v1.12.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+# the conda-build parameters to use for disabling overlinking check
+build_parameters:
+  - ""

--- a/recipe/0003_dont_download_deps.patch
+++ b/recipe/0003_dont_download_deps.patch
@@ -1,0 +1,13 @@
+t a/tools/ci_build/build.py b/tools/ci_build/build.py
+index 79314f345..ec58a7642 100644
+--- a/tools/ci_build/build.py
++++ b/tools/ci_build/build.py
+@@ -753,7 +753,7 @@ def install_python_deps(numpy_version=""):
+     dep_packages.append("sympy>=1.10")
+     dep_packages.append("packaging")
+     dep_packages.append("cerberus")
+-    run_subprocess([sys.executable, "-m", "pip", "install"] + dep_packages)
++    # run_subprocess([sys.executable, "-m", "pip", "install"] + dep_packages)
+
+
+ def setup_test_data(source_onnx_model_dir, dest_model_dir_name, build_dir, configs):

--- a/recipe/0003_dont_download_deps.patch
+++ b/recipe/0003_dont_download_deps.patch
@@ -1,4 +1,4 @@
-t a/tools/ci_build/build.py b/tools/ci_build/build.py
+diff --git a/tools/ci_build/build.py b/tools/ci_build/build.py
 index 79314f345..ec58a7642 100644
 --- a/tools/ci_build/build.py
 +++ b/tools/ci_build/build.py

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -38,3 +38,4 @@ xcopy build-ci\Release\Release\dist\onnxruntime-*.whl onnxruntime-%PKG_VERSION%-
 if errorlevel 1 exit 1
 
 %PYTHON%  -m pip install onnxruntime-%PKG_VERSION%-py3-none-any.whl
+if errorlevel 1 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -34,8 +34,9 @@ set CMAKE_EXTRA_DEFINES= "Protobuf_SRC_ROOT_FOLDER=%LIBRARY_PREFIX%\lib\pkgconfi
 %PYTHON% tools\ci_build\build.py --build_dir build-ci --config Release --update --build --skip_submodule_sync --build_wheel --parallel --enable_lto --use_full_protobuf --cmake_extra_defines %CMAKE_EXTRA_DEFINES%
 if errorlevel 1 exit 1
 
-xcopy build-ci\Release\Release\dist\onnxruntime-*.whl onnxruntime-%PKG_VERSION%-py3-none-any.whl
+xcopy /S /Y /F build-ci\Release\Release\dist\onnxruntime-*.whl onnxruntime-%PKG_VERSION%-py3-none-any.whl*
 if errorlevel 1 exit 1
 
-%PYTHON%  -m pip install onnxruntime-%PKG_VERSION%-py3-none-any.whl
+%PYTHON% -m pip install onnxruntime-%PKG_VERSION%-py3-none-any.whl
 if errorlevel 1 exit 1
+rem Exiting...

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -7,34 +7,34 @@ popd
 
 rem Copy all dependencies that are to be built
 rd /s /q cmake\external\onnx
-xcopy /E /I onnx cmake\external\onnx
+xcopy /E /I /q onnx cmake\external\onnx
 if errorlevel 1 exit 1
 
 rd /s /q cmake\external\eigen
-xcopy /E /I eigen cmake\external\eigen
+xcopy /E /I /q eigen cmake\external\eigen
 if errorlevel 1 exit 1
 
 rd /s /q cmake\external\json
-xcopy /E /I json cmake\external\json
+xcopy /E /I /q json cmake\external\json
 if errorlevel 1 exit 1
 
 rd /s /q cmake\external\pytorch_cpuinfo
-xcopy /E /I pytorch_cpuinfo cmake\external\pytorch_cpuinfo
+xcopy /E /I /q pytorch_cpuinfo cmake\external\pytorch_cpuinfo
 if errorlevel 1 exit 1
 
 pushd cmake\external\SafeInt\safeint
-xcopy /E /I %LIBRARY_PREFIX%\include\SafeInt.hpp .
+xcopy /E /I /q %LIBRARY_PREFIX%\include\SafeInt.hpp .
 if errorlevel 1 exit 1
 popd
 
 rem Create extra cmake defines and associated variables
-set DONT_VECTORIZE="OFF"
-set CMAKE_EXTRA_DEFINES= "Protobuf_PROTOC_EXECUTABLE=%LIBRARY_PREFIX%\bin\protoc" "Protobuf_INCLUDE_DIR=%LIBRARY_PREFIX%\include" "onnxruntime_PREFER_SYSTEM_LIB=ON" "onnxruntime_USE_COREML=OFF" "onnxruntime_DONT_VECTORIZE=%DONT_VECTORIZE%" "onnxruntime_BUILD_SHARED_LIB=ON" "onnxruntime_BUILD_UNIT_TESTS=OFF" "CMAKE_PREFIX_PATH=%LIBRARY_PREFIX%;%CMAKE_PREFIX_PATH%" "CMAKE_VERBOSE_MAKEFILE=ON" 
+if %PKG_NAME% == "onnxruntime-novec" ( set DONT_VECTORIZE="ON" ) else set DONT_VECTORIZE="OFF"
+set CMAKE_EXTRA_DEFINES= "Protobuf_SRC_ROOT_FOLDER=%LIBRARY_PREFIX%\lib\pkgconfig" "onnxruntime_PREFER_SYSTEM_LIB=ON" "onnxruntime_USE_COREML=OFF" "onnxruntime_DONT_VECTORIZE=%DONT_VECTORIZE%" "onnxruntime_BUILD_SHARED_LIB=ON" "onnxruntime_BUILD_UNIT_TESTS=OFF" "CMAKE_PREFIX_PATH=%LIBRARY_PREFIX%" "CMAKE_CXX_FLAGS=/wd4100 /wd4244 /wd4127" "CMAKE_VERBOSE_MAKEFILE=ON" 
 
-%PYTHON% tools\ci_build\build.py --build_dir build-ci --config Release --update --build --skip_submodule_sync --build_wheel --parallel --enable_lto --use_full_protobuf --cmake_generator Ninja --cmake_extra_defines %CMAKE_EXTRA_DEFINES%
+%PYTHON% tools\ci_build\build.py --build_dir build-ci --config Release --update --build --skip_submodule_sync --build_wheel --parallel --enable_lto --use_full_protobuf --cmake_extra_defines %CMAKE_EXTRA_DEFINES%
 if errorlevel 1 exit 1
 
-xcopy build-ci\Release\dist\onnxruntime-*.whl onnxruntime-%PKG_VERSION%-py3-none-any.whl
+xcopy build-ci\Release\Release\dist\onnxruntime-*.whl onnxruntime-%PKG_VERSION%-py3-none-any.whl
 if errorlevel 1 exit 1
 
 %PYTHON%  -m pip install onnxruntime-%PKG_VERSION%-py3-none-any.whl

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,40 @@
+@echo on
+
+rem Copy wil
+pushd wil\include
+xcopy /E /I wil %LIBRARY_PREFIX%\include\wil
+popd
+
+rem Copy all dependencies that are to be built
+rd /s /q cmake\external\onnx
+xcopy /E /I onnx cmake\external\onnx
+if errorlevel 1 exit 1
+
+rd /s /q cmake\external\eigen
+xcopy /E /I eigen cmake\external\eigen
+if errorlevel 1 exit 1
+
+rd /s /q cmake\external\json
+xcopy /E /I json cmake\external\json
+if errorlevel 1 exit 1
+
+rd /s /q cmake\external\pytorch_cpuinfo
+xcopy /E /I pytorch_cpuinfo cmake\external\pytorch_cpuinfo
+if errorlevel 1 exit 1
+
+pushd cmake\external\SafeInt\safeint
+xcopy /E /I %LIBRARY_PREFIX%\include\SafeInt.hpp .
+if errorlevel 1 exit 1
+popd
+
+rem Create extra cmake defines and associated variables
+set DONT_VECTORIZE="OFF"
+set CMAKE_EXTRA_DEFINES= "Protobuf_PROTOC_EXECUTABLE=%LIBRARY_PREFIX%\bin\protoc" "Protobuf_INCLUDE_DIR=%LIBRARY_PREFIX%\include" "onnxruntime_PREFER_SYSTEM_LIB=ON" "onnxruntime_USE_COREML=OFF" "onnxruntime_DONT_VECTORIZE=%DONT_VECTORIZE%" "onnxruntime_BUILD_SHARED_LIB=ON" "onnxruntime_BUILD_UNIT_TESTS=OFF" "CMAKE_PREFIX_PATH=%LIBRARY_PREFIX%;%CMAKE_PREFIX_PATH%" "CMAKE_VERBOSE_MAKEFILE=ON" 
+
+%PYTHON% tools\ci_build\build.py --build_dir build-ci --config Release --update --build --skip_submodule_sync --build_wheel --parallel --enable_lto --use_full_protobuf --cmake_generator Ninja --cmake_extra_defines %CMAKE_EXTRA_DEFINES%
+if errorlevel 1 exit 1
+
+xcopy build-ci\Release\dist\onnxruntime-*.whl onnxruntime-%PKG_VERSION%-py3-none-any.whl
+if errorlevel 1 exit 1
+
+%PYTHON%  -m pip install onnxruntime-%PKG_VERSION%-py3-none-any.whl

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -31,6 +31,7 @@ cmake_extra_defines=( "Protobuf_PROTOC_EXECUTABLE=$BUILD_PREFIX/bin/protoc" \
                       "onnxruntime_USE_COREML=OFF" \
                       "onnxruntime_DONT_VECTORIZE=$DONT_VECTORIZE" \
                       "onnxruntime_BUILD_SHARED_LIB=ON" \
+                      "onnxruntime_BUILD_UNIT_TESTS=OFF" \
                       "CMAKE_PREFIX_PATH=$PREFIX" )
 
 # Copy the defines from the "activate" script (e.g. activate-gcc_linux-aarch64.sh)

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -56,7 +56,8 @@ if [ "$(uname)" == "Darwin" ]; then
         --config Release \
         --update \
         --build \
-        --skip_submodule_sync
+        --skip_submodule_sync \
+        --parallel
 else
     ${PYTHON} tools/ci_build/build.py \
         --enable_lto \
@@ -68,7 +69,8 @@ else
         --config Release \
         --update \
         --build \
-        --skip_submodule_sync
+        --skip_submodule_sync \
+        --parallel
 fi
 
 cp build-ci/Release/dist/onnxruntime-*.whl onnxruntime-${PKG_VERSION}-py3-none-any.whl

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -15,7 +15,6 @@ do
     mv "${external_dir}" "${dest}"
 done
 
-
 pushd "${external_root}/SafeInt/safeint"
 ln -s $PREFIX/include/SafeInt.hpp
 popd
@@ -31,6 +30,7 @@ cmake_extra_defines=( "Protobuf_PROTOC_EXECUTABLE=$BUILD_PREFIX/bin/protoc" \
                       "onnxruntime_PREFER_SYSTEM_LIB=ON" \
                       "onnxruntime_USE_COREML=OFF" \
                       "onnxruntime_DONT_VECTORIZE=$DONT_VECTORIZE" \
+                      "onnxruntime_BUILD_SHARED_LIB=ON" \
                       "CMAKE_PREFIX_PATH=$PREFIX" )
 
 # Copy the defines from the "activate" script (e.g. activate-gcc_linux-aarch64.sh)
@@ -44,18 +44,32 @@ do
     fi
 done
 
-
-python tools/ci_build/build.py \
-    --enable_lto \
-    --build_dir build-ci \
-    --use_full_protobuf \
-    --cmake_extra_defines "${cmake_extra_defines[@]}" \
-    --cmake_generator Ninja \
-    --build_wheel \
-    --config Release \
-    --update \
-    --build \
-    --skip_submodule_sync
+if [ "$(uname)" == "Darwin" ]; then
+    ${PYTHON} tools/ci_build/build.py \
+        --enable_lto \
+        --osx_arch "$(uname -m)" \
+        --build_dir build-ci \
+        --use_full_protobuf \
+        --cmake_extra_defines "${cmake_extra_defines[@]}" \
+        --cmake_generator Ninja \
+        --build_wheel \
+        --config Release \
+        --update \
+        --build \
+        --skip_submodule_sync
+else
+    ${PYTHON} tools/ci_build/build.py \
+        --enable_lto \
+        --build_dir build-ci \
+        --use_full_protobuf \
+        --cmake_extra_defines "${cmake_extra_defines[@]}" \
+        --cmake_generator Ninja \
+        --build_wheel \
+        --config Release \
+        --update \
+        --build \
+        --skip_submodule_sync
+fi
 
 cp build-ci/Release/dist/onnxruntime-*.whl onnxruntime-${PKG_VERSION}-py3-none-any.whl
-python -m pip install onnxruntime-${PKG_VERSION}-py3-none-any.whl
+${PYTHON} -m pip install onnxruntime-${PKG_VERSION}-py3-none-any.whl

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,6 +2,8 @@ MACOSX_DEPLOYMENT_TARGET:  # [osx and x86_64]
   - "10.14"                # [osx and x86_64]
 MACOSX_SDK_VERSION:        # [osx and x86_64]
   - "10.14"                # [osx and x86_64]
+CONDA_BUILD_SYSROOT:       # [osx and x86_64]
+  - /opt/MacOSX10.14.sdk   # [osx and x86_64]
 suffix:
   - ""
   - "-novec"

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -4,6 +4,10 @@ MACOSX_SDK_VERSION:        # [osx and x86_64]
   - "10.14"                # [osx and x86_64]
 CONDA_BUILD_SYSROOT:       # [osx and x86_64]
   - /opt/MacOSX10.14.sdk   # [osx and x86_64]
+cxx_compiler:              # [win]
+  - vs2019                 # [win]
+c_compiler:                # [win]
+  - vs2019                 # [win]
 suffix:
   - ""
   - "-novec"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,8 @@ requirements:
     - packaging
     - sympy >=1.10
     - pybind11
+    - git
+    - patch  # [unix]
   host:
     - pip
     - wheel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,8 +40,7 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake
     - git
-    - libprotobuf 3.19.1 # [not win]
-    - libprotobuf # [win]
+    - libprotobuf 3.20.1
     - ninja
     - patch    # [unix]
     - m2-patch # [win]
@@ -54,12 +53,9 @@ requirements:
     - gmock
     - gtest
     - libdate
-    - libprotobuf 3.19.1         # [not win]
-    - libprotobuf                # [win]
     # See: https://github.com/conda-forge/onnxruntime-feedstock/issues/5
     # We need to statically link protobuf until we link against a system libonnx
-    - libprotobuf-static 3.19.1  # [not win]
-    - libprotobuf-static         # [win]
+    - libprotobuf-static 3.20.1
     - nsync
     - numpy
     - optional-lite

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "onnxruntime" %}
-{% set version = "1.12.0" %}
-
+{% set version = "1.12.1" %}
 
 package:
   name: {{ name|lower }}{{ suffix }}
@@ -8,10 +7,11 @@ package:
 
 source:
   - url: https://github.com/microsoft/onnxruntime/archive/refs/tags/v{{ version }}.tar.gz
-    sha256: de3b79ead1aa6387fe2828f0f94239c98cb4f08b4b6855219872aac19f07a5e3
+    sha256: 302e5a0f368c7d048a9acd1227ac226148ed9c944f8b67d1077ca1b3bb3dcc5b
     patches:
       - 0001_dont_vectorize.patch
       - 0002_use_system_nsync.patch
+      - 0003_dont_download_deps.patch
   - url: https://github.com/onnx/onnx/archive/f7ee1ac60d06abe8e26c9b6bbe1e3db5286b614b.tar.gz
     sha256: 0624860bc300fada6c0f2b5fd18043528bd0e149aad9b3c329d478ab185f17d3
     folder: onnx
@@ -26,25 +26,27 @@ source:
     folder: json
 build:
   number: 0
-  skip: true  # [win]
-  # Since 1.11, power9 seems to be required.
-  skip: true  # [ppc64le]
+  skip: True # [s390x or ppc64le]
+  ignore_run_exports_from:
+    - libprotobuf
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-    - numpy                                  # [build_platform != target_platform]
-    - pybind11                               # [build_platform != target_platform]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - cmake
     - ninja
-    - libprotobuf
+    - libprotobuf 3.19.1
+    - numpy
+    - setuptools
+    - cerberus
+    - packaging
+    - sympy >=1.10
+    - pybind11
   host:
-    - python
     - pip
     - wheel
+    - python
     - boost_mp11
     - flake8
     - flatbuffers !=2.0.6
@@ -55,13 +57,14 @@ requirements:
     - re2
     - optional-lite
     - nsync
-    - libprotobuf
+    - libprotobuf 3.19.1
     # We need to statically link protobuf until we link against a system libonnx
     # See: https://github.com/conda-forge/onnxruntime-feedstock/issues/5
-    - libprotobuf-static
+    - libprotobuf-static 3.19.1
     - numpy
     - pybind11
     - safeint
+    - setuptools
   run:
     - coloredlogs
     - packaging
@@ -82,7 +85,9 @@ test:
     - pip
 
 about:
-  home: https://github.com/microsoft/onnxruntime/
+  home: https://onnxruntime.ai/
+  dev_url: https://github.com/microsoft/onnxruntime/
+  doc_url: https://onnxruntime.ai/docs/
   summary: cross-platform, high performance ML inferencing and training accelerator
   license: MIT
   license_file:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,8 +40,7 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake
     - git
-    - libprotobuf 3.19.1 # [not win]
-    - libprotobuf 3.20.1 # [win]
+    - libprotobuf 3.20.1
     - ninja
     - patch    # [unix]
     - m2-patch # [win]
@@ -56,8 +55,7 @@ requirements:
     - libdate
     # See: https://github.com/conda-forge/onnxruntime-feedstock/issues/5
     # We need to statically link protobuf until we link against a system libonnx
-    - libprotobuf-static 3.19.1 # [not win]
-    - libprotobuf-static 3.20.1 # [win]
+    - libprotobuf-static 3.20.1
     - nsync
     - numpy
     - optional-lite

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,10 @@ source:
   - url: https://github.com/nlohmann/json/archive/refs/tags/v3.10.5.tar.gz
     sha256: 5daca6ca216495edf89d167f808d1d03c4a4d929cef7da5e10f135ae1540c7e4
     folder: json
+  - url: https://github.com/microsoft/wil/archive/e8c599bca6c56c44b6730ad93f6abbc9ecd60fc1.tar.gz  # [win]
+    sha256: 388156309853aaa6e01d177f9b68bd2c6943e5fc073ac6786f9383c1b4438812 # [win]
+    folder: wil # [win]
+
 build:
   number: 0
   skip: True # [s390x or ppc64le]
@@ -36,9 +40,11 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake
     - git
-    - libprotobuf 3.19.1
+    - libprotobuf 3.19.1 # [not win]
+    - libprotobuf # [win]
     - ninja
-    - patch  # [unix]
+    - patch    # [unix]
+    - m2-patch # [win]
     - pybind11
   host:
     - boost_mp11
@@ -48,10 +54,12 @@ requirements:
     - gmock
     - gtest
     - libdate
-    - libprotobuf 3.19.1
+    - libprotobuf 3.19.1         # [not win]
+    - libprotobuf                # [win]
     # See: https://github.com/conda-forge/onnxruntime-feedstock/issues/5
     # We need to statically link protobuf until we link against a system libonnx
-    - libprotobuf-static 3.19.1
+    - libprotobuf-static 3.19.1  # [not win]
+    - libprotobuf-static         # [win]
     - nsync
     - numpy
     - optional-lite

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,8 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake
     - git
-    - libprotobuf 3.20.1
+    - libprotobuf 3.19.1 # [not win]
+    - libprotobuf 3.20.1 # [win]
     - ninja
     - patch    # [unix]
     - m2-patch # [win]
@@ -55,7 +56,8 @@ requirements:
     - libdate
     # See: https://github.com/conda-forge/onnxruntime-feedstock/issues/5
     # We need to statically link protobuf until we link against a system libonnx
-    - libprotobuf-static 3.20.1
+    - libprotobuf-static 3.19.1 # [not win]
+    - libprotobuf-static 3.20.1 # [win]
     - nsync
     - numpy
     - optional-lite

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,38 +35,36 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - cmake
-    - ninja
-    - libprotobuf 3.19.1
-    - numpy
-    - setuptools
-    - cerberus
-    - packaging
-    - sympy >=1.10
-    - pybind11
     - git
+    - libprotobuf 3.19.1
+    - ninja
     - patch  # [unix]
+    - pybind11
   host:
-    - pip
-    - wheel
-    - python
     - boost_mp11
+    - cerberus
     - flake8
     - flatbuffers !=2.0.6
     - gmock
     - gtest
     - libdate
+    - libprotobuf 3.19.1
+    # See: https://github.com/conda-forge/onnxruntime-feedstock/issues/5
+    # We need to statically link protobuf until we link against a system libonnx
+    - libprotobuf-static 3.19.1
+    - nsync
+    - numpy
+    - optional-lite
+    - packaging
+    - pip
+    - pybind11
+    - python
     - python-flatbuffers
     - re2
-    - optional-lite
-    - nsync
-    - libprotobuf 3.19.1
-    # We need to statically link protobuf until we link against a system libonnx
-    # See: https://github.com/conda-forge/onnxruntime-feedstock/issues/5
-    - libprotobuf-static 3.19.1
-    - numpy
-    - pybind11
     - safeint
     - setuptools
+    - sympy >=1.10
+    - wheel
   run:
     - coloredlogs
     - packaging
@@ -92,6 +90,7 @@ about:
   doc_url: https://onnxruntime.ai/docs/
   summary: cross-platform, high performance ML inferencing and training accelerator
   license: MIT
+  license_family: MIT
   license_file:
     - LICENSE
     - cmake/external/onnx/LICENSE


### PR DESCRIPTION
Added a custom `abs.yaml` because we get an overdepending error from `libcurl`, which isn't a direct dependency of the project and is therefore tricky to figure out. 

Apart from that, some Windows specific changes had to be made to the recipe, none of which are present in the `conda-forge` recipe since they haven't added Windows support yet.

Key points: training mode is disabled (not sure if Snowflake needs it), and both the `vec` and `no-vec` options are built.