### PR TITLE
PKG-14952: rebuild onnxruntime 1.24.4 against pybind11 3.0.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
     - patches/fix-problematic-gtests.patch       # [unix]
 
 build:
-  number: 1
+  number: 2
   skip: true  # [py<311]
   string: py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}_{{ ep_variant }}
 


### PR DESCRIPTION
onnxruntime 1.24.4

**Destination channel:** Defaults

### Links

- [PKG-14952](https://anaconda.atlassian.net/browse/PKG-14952)
- [PKG-13552](https://anaconda.atlassian.net/browse/PKG-13552) (parent epic)
- Relevant dependency PRs:
  - AnacondaRecipes/pybind11-feedstock#24 (pybind11 3.0.4 — **MERGED**)
  - AnacondaRecipes/repodata-hotfixes#318 (scope reduction — **applied**)
  - AnacondaRecipes/onnx-feedstock#22 (companion rebuild for the onnx side of the type exchange)

### Explanation of changes:

- **Build number 1 -> 2** (no source change). Rebuild against pybind11 3.0.4 from pkgs/main.
- **Result:** both `onnxruntime` and `onnxruntime-novec` outputs will declare `pybind11-abi ==11` via pybind11-abi's run_export.
- **Why:** onnxruntime accepts ONNX C++ types cross-module from the onnx package. Per Charles's PKG-13552 hotfix-scope analysis, retained in the slim `MISSING_PYBIND11_ABI_VERSION_RANGES` table after #318.

[PKG-14952]: https://anaconda.atlassian.net/browse/PKG-14952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-13552]: https://anaconda.atlassian.net/browse/PKG-13552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ