### PR TITLE
rebuild against CUDA 12.9 + 13.0, add aarch64 CUDA + __cuda

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -42,11 +42,37 @@ if [[ "${target_platform}" == "linux-64" ]]; then
     export GTEST_FILTER="-NhwcTransformerTests.ConvSplit"
 fi
 
+# Build parallelism (see cuda-build-tuning skill). CPU builds can use all
+# cores; CUDA builds are memory-bound (each nvcc template instantiation peaks
+# several GB), so size jobs to the worker's RAM, not its core count, and cap
+# per-nvcc threading + glibc arenas to avoid OOM. Replaces the old hardcoded
+# `--parallel 4`, which throttled CPU builds across the whole matrix.
+if [[ "${ep_variant:-}" == "cuda" ]]; then
+    export MALLOC_ARENA_MAX=2
+    if [[ "${target_platform}" == "linux-aarch64" ]]; then
+        PARALLEL_JOBS=4          # SBSA GPU workers are memory-bound
+        NVCC_THREADS=1
+    else
+        PARALLEL_JOBS=8          # x86 CUDA (was hardcoded 4)
+        NVCC_THREADS=2
+    fi
+else
+    PARALLEL_JOBS=${CPU_COUNT:-4}
+    NVCC_THREADS=1
+fi
+
 if [[ "${ep_variant:-}" == "cuda" ]]; then
     export CUDAHOSTCXX="${CXX}"                # If this isn't included, CUDA will use the system compiler to compile host
                                                 # files, rather than the one in the conda environment, resulting in compiler errors
-    CUDA_ARGS="--use_cuda --cudnn_home ${PREFIX} --cuda_home ${PREFIX} --enable_cuda_profiling --nvcc_threads 3"
-    cmake_extra_defines+=('CUDAToolkit_INCLUDE_DIR="${PREFIX}/targets/x86_64-linux/include/"')
+    # CUDA toolkit headers live under targets/<arch>-linux; NVIDIA uses the SBSA
+    # convention (sbsa-linux) for aarch64, not aarch64-linux.
+    if [[ "${target_platform}" == "linux-aarch64" ]]; then
+        CUDA_TARGET_DIR="sbsa-linux"
+    else
+        CUDA_TARGET_DIR="x86_64-linux"
+    fi
+    CUDA_ARGS="--use_cuda --cudnn_home ${PREFIX} --cuda_home ${PREFIX} --enable_cuda_profiling --nvcc_threads ${NVCC_THREADS}"
+    cmake_extra_defines+=("CUDAToolkit_INCLUDE_DIR=${PREFIX}/targets/${CUDA_TARGET_DIR}/include/")
     # Skipping all tests for CUDA variants, as they're crashing after passing
     # this is related to CUDA Execution Provider cleanup, which fails, as CI images are missing CUDA drivers
     # All the tests are passing locally on CUDA-enabled docker
@@ -68,7 +94,7 @@ ${PYTHON} ${SRC_DIR}/tools/ci_build/build.py \
     --update \
     --build \
     --clean \
-    --parallel 4 \
+    --parallel ${PARALLEL_JOBS} \
     --skip_pip_install \
     --skip_submodule_sync \
     ${RUN_TESTS} \

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -19,21 +19,21 @@ cxx_compiler:                      # [win]
   - vs2022                         # [win]
 
 cuda_compiler_version:
-  - 12.9                           # [linux64 or win64]
+  - 12.9                           # [linux64 or aarch64 or win64]
   - 12.9
-  - 13.1                           # [linux64 or win64]
+  - 13.0                           # [linux64 or aarch64 or win64]
 
 suffix:
   - ""
   - "-novec"
 ep_variant:
-  - "cuda"                         # [linux64 or win64]
+  - "cuda"                         # [linux64 or aarch64 or win64]
   - "cpu"
-  - "cuda"                         # [linux64 or win64]
+  - "cuda"                         # [linux64 or aarch64 or win64]
 
-zip_keys:                          # [linux64 or win64]
-  -                                # [linux64 or win64]
-    - cuda_compiler_version        # [linux64 or win64]
-    - ep_variant                   # [linux64 or win64]
+zip_keys:                          # [linux64 or aarch64 or win64]
+  -                                # [linux64 or aarch64 or win64]
+    - cuda_compiler_version        # [linux64 or aarch64 or win64]
+    - ep_variant                   # [linux64 or aarch64 or win64]
     - c_compiler                   # [win]
     - cxx_compiler                 # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
     - patches/fix-problematic-gtests.patch       # [unix]
 
 build:
-  number: 1
+  number: 2
   skip: true  # [py<311]
   string: py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}_{{ ep_variant }}
 
@@ -103,6 +103,8 @@ outputs:
         - protobuf
         - python-flatbuffers
         - sympy
+        # gate the CUDA build to GPU hosts; unbounded — cuda-version handles the version
+        - __cuda            # [(ep_variant == "cuda")]
       run_constrained:
         - onnxruntime <0a0  # [suffix == "-novec"]
     test:                          # [(ep_variant == "cpu")]
@@ -135,6 +137,9 @@ outputs:
         - libcudnn-dev                                 # [(ep_variant == "cuda")]
         - libcufft-dev                                 # [(ep_variant == "cuda")]
         - libcublas-dev                                # [(ep_variant == "cuda")]
+      run:
+        # gate the CUDA build to GPU hosts; unbounded — cuda-version handles the version
+        - __cuda                                       # [(ep_variant == "cuda")]
       run_constrained:
         - onnxruntime <0a0       # [suffix == "-novec"]
     test:                        # [(ep_variant == "cpu")]


### PR DESCRIPTION
onnxruntime - rebuild against CUDA 12.9 + 13.0, add linux-aarch64 CUDA, add `__cuda` to run

**Destination channel:** defaults

### Links

- [PKG-14685](https://anaconda.atlassian.net/browse/PKG-14685)
- [PKG-13074 (2026Q2 AI & Growth — CUDA coverage epic)](https://anaconda.atlassian.net/browse/PKG-13074)
- [Upstream repository](https://github.com/microsoft/onnxruntime)

### Explanation of changes:

- **CUDA 13.1 → 13.0** (CBC) to match the Q2 CUDA-coverage standard of 12.9 + 13.0 (PKG-13074).
- **Add linux-aarch64 CUDA** (new platform coverage):
- **`__cuda` (unbounded) added to `run`** of the cuda variant on both the python and `-cpp` outputs — gates the GPU build off non-GPU hosts; `cuda-version` handles the version (per the Apr-2026 CUDA Variant Packaging decision).


[PKG-14685]: https://anaconda.atlassian.net/browse/PKG-14685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ